### PR TITLE
20180201 update

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,7 @@ libinotify-kqueue
 =================
 
 Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
 
 The purpose of this library is to provide inotify API on the
 *BSD family of operating systems. The library uses kqueue(2)

--- a/compat.h
+++ b/compat.h
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/compat.h
+++ b/compat.h
@@ -97,13 +97,6 @@ typedef struct {
     pthread_mutex_destroy(&(sem)->mutex); \
 })
 
-#ifndef SLIST_FOREACH_SAFE
-#define SLIST_FOREACH_SAFE(var, head, field, tvar)			\
-	for ((var) = SLIST_FIRST((head));				\
-	     (var) && ((tvar) = SLIST_NEXT((var), field), 1);		\
-	     (var) = (tvar))
-#endif
-
 #ifndef DTTOIF
 #define DTTOIF(dirtype) ((dirtype) << 12)
 #endif

--- a/compat.h
+++ b/compat.h
@@ -103,12 +103,6 @@ typedef struct {
 	     (var) && ((tvar) = SLIST_NEXT((var), field), 1);		\
 	     (var) = (tvar))
 #endif
-#ifndef SLIST_REMOVE_AFTER
-#define SLIST_REMOVE_AFTER(elm, field) do {				\
-	SLIST_NEXT(elm, field) =					\
-	    SLIST_NEXT(SLIST_NEXT(elm, field), field);			\
-} while (0)
-#endif
 
 #ifndef DTTOIF
 #define DTTOIF(dirtype) ((dirtype) << 12)

--- a/compat/atfuncs.c
+++ b/compat/atfuncs.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/compat/fdopendir.c
+++ b/compat/fdopendir.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/compat/fstatat.c
+++ b/compat/fstatat.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/compat/ik_atomic.c
+++ b/compat/ik_atomic.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2015 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2015 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/compat/ik_atomic.h
+++ b/compat/ik_atomic.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2015 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2015 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/compat/openat.c
+++ b/compat/openat.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/compat/pthread_barrier.c
+++ b/compat/pthread_barrier.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/compat/stdatomic.h
+++ b/compat/stdatomic.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright (c) 2011 Ed Schouten <ed@FreeBSD.org>
  *                    David Chisnall <theraven@FreeBSD.org>
  * All rights reserved.

--- a/compat/tree.h
+++ b/compat/tree.h
@@ -3,6 +3,8 @@
 /* $FreeBSD: head/sys/sys/tree.h 277642 2015-01-24 12:43:36Z kib $ */
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
  * Copyright 2002 Niels Provos <provos@citi.umich.edu>
  * All rights reserved.
  *

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libinotify],[20170711],[https://github.com/libinotify-kqueue/libinotify-kqueue/],[libinotify])
+AC_INIT([libinotify],[20180201],[https://github.com/libinotify-kqueue/libinotify-kqueue/],[libinotify])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -275,7 +275,7 @@ AC_COMPILE_IFELSE(
 AC_MSG_RESULT($have_note_read)
 
 
-AC_MSG_CHECKING(for NOTE_EXTEND on renaming of file in subdirectory)
+AC_MSG_CHECKING(for NOTE_EXTEND on moving of a file into the watched subdirectory)
 rm -rf iktestdir
 mkdir iktestdir
 touch iktestfile
@@ -305,12 +305,46 @@ AC_RUN_IFELSE(
     ])
 ],
 [
-    AC_DEFINE([HAVE_NOTE_EXTEND_ON_SUBFILE_RENAME],[1],[Define to 1 if rename set NODE_EXTEND flag])
+    AC_DEFINE([HAVE_NOTE_EXTEND_ON_MOVE_TO],[1],[Define to 1 if move_to sets NODE_EXTEND flag])
+    AC_MSG_RESULT(yes)
+],
+    AC_MSG_RESULT(no)
+)
+
+AC_MSG_CHECKING(for NOTE_EXTEND on moving of a file from the watched subdirectory)
+AC_RUN_IFELSE(
+[
+    AC_LANG_PROGRAM(
+    [
+        @%:@include <sys/types.h>
+        @%:@include <sys/event.h>
+        @%:@include <sys/time.h>
+        @%:@include <stdio.h>
+        @%:@include <fcntl.h>
+    ],
+    [
+        int fd, kq;
+        struct kevent ev;
+        static const struct timespec tout = { 1, 0 };
+
+        if ((fd = open("iktestdir", O_RDONLY)) == -1) return 1;
+        if ((kq = kqueue()) == -1) return 1;
+        EV_SET(&ev, fd, EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_ONESHOT,
+            NOTE_WRITE | NOTE_EXTEND, 0, 0);
+        if (kevent(kq, &ev, 1, NULL, 0, &tout) == -1) return 1;
+        if (rename ("iktestdir/iktestfile", "iktestfile") == -1) return 1;
+        if (kevent(kq, NULL, 0, &ev, 1, &tout) != 1) return 1;
+        return (ev.fflags & NOTE_EXTEND) ? 0 : 1;
+    ])
+],
+[
+    AC_DEFINE([HAVE_NOTE_EXTEND_ON_MOVE_FROM],[1],[Define to 1 if move_from sets NODE_EXTEND flag])
     AC_MSG_RESULT(yes)
 ],
     AC_MSG_RESULT(no)
 )
 rm -rf iktestdir
+rm iktestfile
 
 
 # There are three ways we can reread directory opened already. Namely:

--- a/controller.c
+++ b/controller.c
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2015 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/dep-list.c
+++ b/dep-list.c
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/dep-list.c
+++ b/dep-list.c
@@ -48,7 +48,7 @@ dl_print (const dep_list *dl)
 {
     dep_node *dn;
 
-    SLIST_FOREACH (dn, &dl->head, next) {
+    DL_FOREACH (dn, dl) {
         printf ("%lld:%s ", (long long int) dn->item->inode, dn->item->path);
     }
     printf ("\n");
@@ -188,7 +188,7 @@ dl_shallow_copy (const dep_list *dl)
     dep_node *cp = NULL;
     dep_node *iter;
 
-    SLIST_FOREACH (iter, &dl->head, next) {
+    DL_FOREACH (iter, dl) {
         dep_node *dn = dn_create (iter->item);
         if (dn == NULL) {
                 perror_msg ("Failed to allocate a new element during shallow copy");
@@ -340,7 +340,7 @@ error:
         dep_node *added_list##_prev = NULL;                             \
                                                                         \
         int matched = 0;                                                \
-        SLIST_FOREACH (added_list##_iter, &added_list->head, next) {    \
+        DL_FOREACH (added_list##_iter, added_list) {                    \
             if (match_expr) {                                           \
                 matched = 1;                                            \
                 ++productive;                                           \
@@ -530,7 +530,7 @@ dl_emit_single_cb_on (dep_list        *list,
     if (cb == NULL)
         return;
 
-    SLIST_FOREACH (iter, &list->head, next) {
+    DL_FOREACH (iter, list) {
         (cb) (udata, iter->item);
     }
 }

--- a/dep-list.c
+++ b/dep-list.c
@@ -141,25 +141,15 @@ dl_insert (dep_list* dl, dep_item* di)
 }
 
 /**
- * Remove item after specified from a list.
+ * Remove specified item from a list.
  *
- * @param[in] dl      A pointer to a list.
- * @param[in] prev_di A pointer to a list item prepending removed one.
- *     Should be NULL to remove first node from a list.
+ * @param[in] dl A pointer to a list.
+ * @param[in] di A pointer to a list item to remove.
  **/
 void
-dl_remove_after (dep_list* dl, dep_item* prev_di)
+dl_remove (dep_list* dl, dep_item* di)
 {
-    dep_item *di;
-
-    if (prev_di) {
-        di = SLIST_NEXT (prev_di, next);
-        SLIST_REMOVE_AFTER (prev_di, next);
-    } else {
-        di = SLIST_FIRST (&dl->head);
-        SLIST_REMOVE_HEAD (&dl->head, next);
-    }
-
+    SLIST_REMOVE (&dl->head, di, dep_item, next);
     di_free (di);
 }
 
@@ -479,12 +469,9 @@ dl_calculate (dep_list           *before,
     }
 
     /* Replace all changed items from before list with items from after list */
-    dep_item *di_prev = NULL;
     DL_FOREACH_SAFE (di_from, before, tmp) {
-        if (di_from->type & DI_UNCHANGED) {
-            di_prev = di_from;
-        } else {
-            dl_remove_after (before, di_prev);
+        if (!(di_from->type & DI_UNCHANGED)) {
+            dl_remove (before, di_from);
         }
     }
     if (after != NULL) {

--- a/dep-list.c
+++ b/dep-list.c
@@ -335,7 +335,7 @@ error:
                                                                         \
     int productive = 0;                                                 \
                                                                         \
-    SLIST_FOREACH_SAFE (removed_list##_iter, &removed_list->head, next, tmp) { \
+    DL_FOREACH_SAFE (removed_list##_iter, removed_list, tmp) {          \
         dep_node *added_list##_iter;                                    \
         dep_node *added_list##_prev = NULL;                             \
                                                                         \

--- a/dep-list.h
+++ b/dep-list.h
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/dep-list.h
+++ b/dep-list.h
@@ -31,6 +31,7 @@
 
 #define DI_UNCHANGED S_IXOTH /* dep_item remained unchanged between listings */
 #define DI_REPLACED  S_IROTH /* dep_item was replaced by other item */
+#define DI_READDED   DI_REPLACED /* dep_item replaced other item */
 #define DI_MOVED     S_IWOTH /* dep_item was renamed between listings */
 
 #define S_IFUNK 0000000 /* mode_t extension. File type is unknown */
@@ -44,6 +45,7 @@ typedef struct dep_item {
     SLIST_ENTRY(dep_item) next;
     ino_t inode;
     mode_t type;
+    struct dep_item *cookie;
     char path[];
 } dep_item;
 

--- a/dep-list.h
+++ b/dep-list.h
@@ -48,13 +48,15 @@
 typedef struct dep_item {
     union {
         RB_ENTRY(dep_item) tree_link;
-        SLIST_ENTRY(dep_item) list_link;
+        struct {
+            SLIST_ENTRY(dep_item) list_link;
+            struct dep_item *replacee;
+            struct dep_item *moved_from;
+        };
         const char *ext_path;
     };
     ino_t inode;
     mode_t type;
-    struct dep_item *replacee;
-    struct dep_item *moved_from;
     char path[];
 } dep_item;
 

--- a/dep-list.h
+++ b/dep-list.h
@@ -33,16 +33,24 @@
 #define DI_REPLACED  S_IROTH /* dep_item was replaced by other item */
 #define DI_READDED   DI_REPLACED /* dep_item replaced other item */
 #define DI_MOVED     S_IWOTH /* dep_item was renamed between listings */
+#define DI_EXT_PATH  S_IRWXO /* special dep_item intended for search only */
 
 #define S_IFUNK 0000000 /* mode_t extension. File type is unknown */
 #define S_ISUNK(m) (((m) & S_IFMT) == S_IFUNK)
 
-#define DL_FOREACH(di, dl) SLIST_FOREACH ((di), &(dl)->head, next)
+#define CL_FOREACH(di, dl) \
+    SLIST_FOREACH ((di), &(dl)->head, list_link)
+#define DL_FOREACH(di, dl) \
+    RB_FOREACH ((di), dep_tree, &(dl)->head)
 #define DL_FOREACH_SAFE(di, dl, tmp_di) \
-    SLIST_FOREACH_SAFE ((di), &(dl)->head, next, (tmp_di))
+    RB_FOREACH_SAFE ((di), dep_tree, &(dl)->head, (tmp_di))
 
 typedef struct dep_item {
-    SLIST_ENTRY(dep_item) next;
+    union {
+        RB_ENTRY(dep_item) tree_link;
+        SLIST_ENTRY(dep_item) list_link;
+        const char *ext_path;
+    };
     ino_t inode;
     mode_t type;
     struct dep_item *replacee;
@@ -51,8 +59,12 @@ typedef struct dep_item {
 } dep_item;
 
 typedef struct dep_list {
-    SLIST_HEAD(, dep_item) head;
+    RB_HEAD(dep_tree, dep_item) head;
 } dep_list;
+
+typedef struct chg_list {
+    SLIST_HEAD(, dep_item) head;
+} chg_list;
 
 typedef void (* single_entry_cb) (void *udata, dep_item *di);
 typedef void (* dual_entry_cb)   (void *udata,
@@ -73,20 +85,22 @@ void      dl_init         (dep_list *dl);
 dep_list* dl_create       ();
 void      dl_insert       (dep_list *dl, dep_item *di);
 void      dl_remove       (dep_list *dl, dep_item *di);
-void      dl_print        (const dep_list *dl);
+void      dl_print        (dep_list *dl);
 void      dl_free         (dep_list *dl);
-void      dl_join         (dep_list *dl_target, dep_list *dl_source);
+void      dl_join         (dep_list *dl_target, chg_list *dl_source);
 dep_item* dl_find         (dep_list *dl, const char *path);
-dep_list* dl_readdir      (DIR *dir, dep_list *before);
+chg_list* dl_readdir      (DIR *dir, dep_list *before);
 
 void
 dl_calculate (dep_list            *before,
-              dep_list            *after,
+              chg_list            *after,
               const traverse_cbs  *cbs,
               void                *udata);
 
 #define di_settype(di, tp) do { \
     (di)->type = ((di)->type & ~S_IFMT) | ((tp) & S_IFMT); \
 } while (0)
+
+RB_PROTOTYPE(dep_tree, dep_item, tree_link, dep_item_cmp);
 
 #endif /* __DEP_LIST_H__ */

--- a/dep-list.h
+++ b/dep-list.h
@@ -68,11 +68,14 @@ typedef struct traverse_cbs {
 
 dep_item* di_create       (const char *path, ino_t inode, mode_t type);
 void      di_free         (dep_item *di);
+dep_list* dl_alloc        ();
+void      dl_init         (dep_list *dl);
 dep_list* dl_create       ();
 void      dl_insert       (dep_list *dl, dep_item *di);
 void      dl_remove_after (dep_list *dl, dep_item *di);
 void      dl_print        (const dep_list *dl);
 void      dl_free         (dep_list *dl);
+void      dl_join         (dep_list *dl_target, dep_list *dl_source);
 dep_item* dl_find         (dep_list *dl, const char *path);
 dep_list* dl_readdir      (DIR *dir, dep_list *before);
 

--- a/dep-list.h
+++ b/dep-list.h
@@ -45,7 +45,8 @@ typedef struct dep_item {
     SLIST_ENTRY(dep_item) next;
     ino_t inode;
     mode_t type;
-    struct dep_item *cookie;
+    struct dep_item *replacee;
+    struct dep_item *moved_from;
     char path[];
 } dep_item;
 

--- a/dep-list.h
+++ b/dep-list.h
@@ -30,6 +30,8 @@
 #include <sys/stat.h>  /* mode_t */
 
 #define DI_UNCHANGED S_IXOTH /* dep_item remained unchanged between listings */
+#define DI_REPLACED  S_IROTH /* dep_item was replaced by other item */
+#define DI_MOVED     S_IWOTH /* dep_item was renamed between listings */
 
 #define S_IFUNK 0000000 /* mode_t extension. File type is unknown */
 #define S_ISUNK(m) (((m) & S_IFMT) == S_IFUNK)
@@ -53,23 +55,16 @@ typedef struct dep_list {
     SLIST_HEAD(, dep_node) head;
 } dep_list;
 
-typedef void (* no_entry_cb)     (void *udata);
 typedef void (* single_entry_cb) (void *udata, dep_item *di);
 typedef void (* dual_entry_cb)   (void *udata,
                                   dep_item *from_di,
                                   dep_item *to_di);
-typedef void (* list_cb)         (void *udata, const dep_list *list);
-
 
 typedef struct traverse_cbs {
     single_entry_cb  added;
     single_entry_cb  removed;
     single_entry_cb  replaced;
-    dual_entry_cb    overwritten;
     dual_entry_cb    moved;
-    list_cb          many_added;
-    list_cb          many_removed;
-    no_entry_cb      names_updated;
 } traverse_cbs;
 
 dep_item* di_create       (const char *path, ino_t inode, mode_t type);
@@ -84,7 +79,7 @@ void      dl_free         (dep_list *dl);
 dep_node* dl_find         (dep_list *dl, const char *path);
 dep_list* dl_readdir      (DIR *dir, dep_list *before);
 
-int
+void
 dl_calculate (dep_list            *before,
               dep_list            *after,
               const traverse_cbs  *cbs,

--- a/dep-list.h
+++ b/dep-list.h
@@ -72,7 +72,7 @@ dep_list* dl_alloc        ();
 void      dl_init         (dep_list *dl);
 dep_list* dl_create       ();
 void      dl_insert       (dep_list *dl, dep_item *di);
-void      dl_remove_after (dep_list *dl, dep_item *di);
+void      dl_remove       (dep_list *dl, dep_item *di);
 void      dl_print        (const dep_list *dl);
 void      dl_free         (dep_list *dl);
 void      dl_join         (dep_list *dl_target, dep_list *dl_source);

--- a/dep-list.h
+++ b/dep-list.h
@@ -36,23 +36,19 @@
 #define S_IFUNK 0000000 /* mode_t extension. File type is unknown */
 #define S_ISUNK(m) (((m) & S_IFMT) == S_IFUNK)
 
-#define DL_FOREACH(dn, dl) SLIST_FOREACH ((dn), &(dl)->head, next)
-#define DL_FOREACH_SAFE(dn, dl, tmp_dn) \
-    SLIST_FOREACH_SAFE ((dn), &(dl)->head, next, (tmp_dn))
+#define DL_FOREACH(di, dl) SLIST_FOREACH ((di), &(dl)->head, next)
+#define DL_FOREACH_SAFE(di, dl, tmp_di) \
+    SLIST_FOREACH_SAFE ((di), &(dl)->head, next, (tmp_di))
 
 typedef struct dep_item {
+    SLIST_ENTRY(dep_item) next;
     ino_t inode;
     mode_t type;
     char path[];
 } dep_item;
 
-typedef struct dep_node {
-    SLIST_ENTRY(dep_node) next;
-    dep_item *item;
-} dep_node;
-
 typedef struct dep_list {
-    SLIST_HEAD(, dep_node) head;
+    SLIST_HEAD(, dep_item) head;
 } dep_list;
 
 typedef void (* single_entry_cb) (void *udata, dep_item *di);
@@ -70,13 +66,11 @@ typedef struct traverse_cbs {
 dep_item* di_create       (const char *path, ino_t inode, mode_t type);
 void      di_free         (dep_item *di);
 dep_list* dl_create       ();
-dep_node* dl_insert       (dep_list *dl, dep_item *di);
-void      dl_remove_after (dep_list *dl, dep_node *dn);
+void      dl_insert       (dep_list *dl, dep_item *di);
+void      dl_remove_after (dep_list *dl, dep_item *di);
 void      dl_print        (const dep_list *dl);
-dep_list* dl_shallow_copy (const dep_list *dl);
-void      dl_shallow_free (dep_list *dl);
 void      dl_free         (dep_list *dl);
-dep_node* dl_find         (dep_list *dl, const char *path);
+dep_item* dl_find         (dep_list *dl, const char *path);
 dep_list* dl_readdir      (DIR *dir, dep_list *before);
 
 void

--- a/dep-list.h
+++ b/dep-list.h
@@ -33,6 +33,8 @@
 #define S_ISUNK(m) (((m) & S_IFMT) == S_IFUNK)
 
 #define DL_FOREACH(dn, dl) SLIST_FOREACH ((dn), &(dl)->head, next)
+#define DL_FOREACH_SAFE(dn, dl, tmp_dn) \
+    SLIST_FOREACH_SAFE ((dn), &(dl)->head, next, (tmp_dn))
 
 typedef struct dep_item {
     ino_t inode;

--- a/event-queue.c
+++ b/event-queue.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2016-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/event-queue.h
+++ b/event-queue.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2016-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/inotify-watch.c
+++ b/inotify-watch.c
@@ -154,7 +154,7 @@ iwatch_init (worker *wrk, int fd, uint32_t flags)
             iwatch_free (iw);
             return NULL;
         }
-        dep_list *deps = dl_readdir (dir, NULL);
+        chg_list *deps = dl_readdir (dir, NULL);
         if (deps == NULL) {
             perror_msg ("Directory listing of %d failed", fd);
             closedir (dir);

--- a/inotify-watch.c
+++ b/inotify-watch.c
@@ -181,9 +181,9 @@ iwatch_init (worker *wrk, int fd, uint32_t flags)
 
     if (S_ISDIR (st.st_mode)) {
 
-        dep_node *iter;
+        dep_item *iter;
         DL_FOREACH (iter, iw->deps) {
-            iwatch_add_subwatch (iw, iter->item);
+            iwatch_add_subwatch (iw, iter);
         }
     }
     return iw;
@@ -364,18 +364,18 @@ iwatch_update_flags (i_watch *iw, uint32_t flags)
 
     if (iw->deps != NULL) {
         /* Mark unwatched subfiles */
-        dep_node *iter;
+        dep_item *iter;
         DL_FOREACH (iter, iw->deps) {
-            if (watch_set_find (&iw->watches, iter->item->inode) == NULL) {
-                iter->item->type |= DI_UNCHANGED;
+            if (watch_set_find (&iw->watches, iter->inode) == NULL) {
+                iter->type |= DI_UNCHANGED;
             }
         }
 
         /* And finally try to watch marked items */
         DL_FOREACH (iter, iw->deps) {
-            if (iter->item->type & DI_UNCHANGED) {
-                iwatch_add_subwatch (iw, iter->item);
-                iter->item->type &= ~DI_UNCHANGED;
+            if (iter->type & DI_UNCHANGED) {
+                iwatch_add_subwatch (iw, iter);
+                iter->type &= ~DI_UNCHANGED;
             }
         }
     }

--- a/inotify-watch.c
+++ b/inotify-watch.c
@@ -363,22 +363,20 @@ iwatch_update_flags (i_watch *iw, uint32_t flags)
     }
 
     if (iw->deps != NULL) {
-        /* create list of unwatched subfiles */
-        dep_list *dl = dl_create ();
-        if (dl == NULL) {
-            return;
-        }
+        /* Mark unwatched subfiles */
         dep_node *iter;
         DL_FOREACH (iter, iw->deps) {
             if (watch_set_find (&iw->watches, iter->item->inode) == NULL) {
-                dl_insert (dl, iter->item);
+                iter->item->type |= DI_UNCHANGED;
             }
         }
 
-        /* And finally try to watch that list */
-        DL_FOREACH (iter, dl) {
-            iwatch_add_subwatch (iw, iter->item);
+        /* And finally try to watch marked items */
+        DL_FOREACH (iter, iw->deps) {
+            if (iter->item->type & DI_UNCHANGED) {
+                iwatch_add_subwatch (iw, iter->item);
+                iter->item->type &= ~DI_UNCHANGED;
+            }
         }
-        dl_shallow_free (dl);
     }
 }

--- a/inotify-watch.c
+++ b/inotify-watch.c
@@ -73,7 +73,7 @@ iwatch_want_skip_subfiles (int fd)
     ret = fstatvfs (fd, &st);
 #endif
     if (ret == -1) {
-        perror_msg ("fstatfs failed on %d");
+        perror_msg ("fstatfs failed on %d, fd");
         return 0;
     }
 

--- a/inotify-watch.c
+++ b/inotify-watch.c
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/inotify-watch.h
+++ b/inotify-watch.h
@@ -46,7 +46,7 @@ struct i_watch {
     uint32_t flags;            /* flags in the inotify format */
     ino_t inode;               /* inode number of watched inode */
     dev_t dev;                 /* device number of watched inode */
-    dep_list *deps;            /* dependence list of inotify watch */
+    dep_list deps;             /* dependence list of inotify watch */
     watch_set watches;         /* kqueue watches of inotify watch */
     SLIST_ENTRY(i_watch) next; /* pointer to the next inotify watch in list */
 };

--- a/inotify-watch.h
+++ b/inotify-watch.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/bugs_test.cc
+++ b/tests/bugs_test.cc
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/bugs_test.hh
+++ b/tests/bugs_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/action.cc
+++ b/tests/core/action.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/action.hh
+++ b/tests/core/action.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/consumer.cc
+++ b/tests/core/consumer.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/consumer.hh
+++ b/tests/core/consumer.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/core.hh
+++ b/tests/core/core.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/event.cc
+++ b/tests/core/event.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/event.hh
+++ b/tests/core/event.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/inotify_client.cc
+++ b/tests/core/inotify_client.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/inotify_client.hh
+++ b/tests/core/inotify_client.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/journal.cc
+++ b/tests/core/journal.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/journal.hh
+++ b/tests/core/journal.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/log.cc
+++ b/tests/core/log.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/log.hh
+++ b/tests/core/log.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/platform.hh
+++ b/tests/core/platform.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/request.cc
+++ b/tests/core/request.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/request.hh
+++ b/tests/core/request.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/response.cc
+++ b/tests/core/response.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/response.hh
+++ b/tests/core/response.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/test.cc
+++ b/tests/core/test.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/core/test.hh
+++ b/tests/core/test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/event_queue_test.cc
+++ b/tests/event_queue_test.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2016 Vladimir Kondratyev <wulf@cicgroup.ru>
+  Copyright (c) 2016 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/event_queue_test.hh
+++ b/tests/event_queue_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
-  Copyright (c) 2016 Vladimir Kondratyev <wulf@cicgroup.ru>
+  Copyright (c) 2016 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/fail_test.cc
+++ b/tests/fail_test.cc
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2015 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2015 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/fail_test.hh
+++ b/tests/fail_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/notifications_dir_test.cc
+++ b/tests/notifications_dir_test.cc
@@ -171,7 +171,6 @@ void notifications_dir_test::run ()
             contains (received, event ("one", wid, IN_MODIFY)));
 
 
-#if defined(__linux__) || defined(HAVE_NOTE_EXTEND_ON_SUBFILE_RENAME)
     cons.output.reset ();
     cons.input.receive ();
 
@@ -179,6 +178,7 @@ void notifications_dir_test::run ()
 
     cons.output.wait ();
     received = cons.output.registered ();
+#if defined(__linux__) || defined(HAVE_NOTE_EXTEND_ON_MOVE_FROM)
     should ("receive IN_MOVED_FROM event on moving file from directory "
             "to another location within the same mount point",
             contains (received, event ("one", wid, IN_MOVED_FROM)));
@@ -189,7 +189,6 @@ void notifications_dir_test::run ()
 #endif
 
 
-#if defined(__linux__) || defined(HAVE_NOTE_EXTEND_ON_SUBFILE_RENAME)
     cons.output.reset ();
     cons.input.receive ();
 
@@ -197,6 +196,7 @@ void notifications_dir_test::run ()
 
     cons.output.wait ();
     received = cons.output.registered ();
+#if defined(__linux__) || defined(HAVE_NOTE_EXTEND_ON_MOVE_TO)
     should ("receive IN_MOVED_TO event on moving file to directory "
             "from another location within the same mount point",
             contains (received, event ("one", wid, IN_MOVED_TO)));

--- a/tests/notifications_dir_test.cc
+++ b/tests/notifications_dir_test.cc
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/notifications_dir_test.hh
+++ b/tests/notifications_dir_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/notifications_test.cc
+++ b/tests/notifications_test.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/notifications_test.hh
+++ b/tests/notifications_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/open_close_test.cc
+++ b/tests/open_close_test.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/open_close_test.hh
+++ b/tests/open_close_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/start_stop_dir_test.cc
+++ b/tests/start_stop_dir_test.cc
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/start_stop_dir_test.hh
+++ b/tests/start_stop_dir_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/start_stop_test.cc
+++ b/tests/start_stop_test.cc
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/start_stop_test.hh
+++ b/tests/start_stop_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/symlink_test.cc
+++ b/tests/symlink_test.cc
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/symlink_test.hh
+++ b/tests/symlink_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/update_flags_dir_test.cc
+++ b/tests/update_flags_dir_test.cc
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/update_flags_dir_test.hh
+++ b/tests/update_flags_dir_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/update_flags_test.cc
+++ b/tests/update_flags_test.cc
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/tests/update_flags_test.hh
+++ b/tests/update_flags_test.hh
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/utils.c
+++ b/utils.c
@@ -1,13 +1,13 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
-
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
   Copyright 2008, 2013, 2014
       The Board of Trustees of the Leland Stanford Junior University
   Copyright (c) 2004, 2005, 2006
       by Internet Systems Consortium, Inc. ("ISC")
   Copyright (c) 1991, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001,
       2002, 2003 by The Internet Software Consortium and Rich Salz
+  SPDX-License-Identifier: MIT AND ISC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/utils.h
+++ b/utils.h
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/watch-set.c
+++ b/watch-set.c
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/watch-set.h
+++ b/watch-set.h
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/watch.c
+++ b/watch.c
@@ -78,7 +78,8 @@ inotify_to_kqueue (uint32_t flags, watch_flags_t wf)
     if (!(wf & WF_ISSUBWATCH)) {
         if (S_ISDIR (wf)) {
             result |= NOTE_WRITE;
-#ifdef HAVE_NOTE_EXTEND_ON_SUBFILE_RENAME
+#if defined(HAVE_NOTE_EXTEND_ON_MOVE_TO) || \
+    defined(HAVE_NOTE_EXTEND_ON_MOVE_FROM)
             result |= NOTE_EXTEND;
 #endif
         }

--- a/watch.c
+++ b/watch.c
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/watch.h
+++ b/watch.h
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -408,15 +408,13 @@ produce_notifications (worker *wrk, struct kevent *event)
         /* Deaggregate inotify events */
         for (i = 0; i < nitems (ie_order); i++) {
             if (i_flags & ie_order[i]) {
-                dep_node *iter = NULL;
+                dep_item *iter = NULL;
                 /* Report deaggregated items */
                 DL_FOREACH (iter, iw->deps) {
-                    dep_item *di = iter->item;
-
-                    if (di->inode == w->inode) {
+                    if (iter->inode == w->inode) {
                         enqueue_event (iw,
                                        ie_order[i] | (i_flags & ~IN_ALL_EVENTS),
-                                       di);
+                                       iter);
                     }
                 }
             }

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -273,7 +273,6 @@ produce_directory_diff (i_watch *iw, struct kevent *event)
         if (errno == ENOENT) {
             /* Why do I skip ENOENT? Because the directory could be deleted
              * at this point */
-            changes = dl_create ();
             goto do_diff;
         }
         perror_msg ("Failed to reopen directory for listing");
@@ -284,7 +283,7 @@ produce_directory_diff (i_watch *iw, struct kevent *event)
     rewinddir(dir);
 #endif
 
-    changes = dl_readdir (dir, iw->deps);
+    changes = dl_readdir (dir, &iw->deps);
 
 #if READDIR_DOES_OPENDIR > 0
     closedir (dir);
@@ -301,7 +300,7 @@ do_diff:
     ctx.iw = iw;
     ctx.fflags = event->fflags;
 
-    dl_calculate (iw->deps, changes, &cbs, &ctx);
+    dl_calculate (&iw->deps, changes, &cbs, &ctx);
 }
 
 /**
@@ -409,7 +408,7 @@ produce_notifications (worker *wrk, struct kevent *event)
             if (i_flags & ie_order[i]) {
                 dep_item *iter = NULL;
                 /* Report deaggregated items */
-                DL_FOREACH (iter, iw->deps) {
+                DL_FOREACH (iter, &iw->deps) {
                     if (iter->inode == w->inode) {
                         enqueue_event (iw,
                                        ie_order[i] | (i_flags & ~IN_ALL_EVENTS),

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -469,7 +469,7 @@ worker_thread (void *arg)
                     }
 #ifdef EVFILT_USER
                 } else if (received[i].filter == EVFILT_USER) {
-                    cmd = (worker_cmd *)received[i].data;
+                    cmd = (worker_cmd *)(intptr_t)received[i].data;
                     process_command (wrk, cmd);
 #else
                 } else if (received[i].filter == EVFILT_READ) {

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -159,7 +159,7 @@ handle_added (void *udata, dep_item *di)
     assert (ctx->iw != NULL);
 
     iwatch_add_subwatch (ctx->iw, di);
-#ifdef HAVE_NOTE_EXTEND_ON_SUBFILE_RENAME
+#ifdef HAVE_NOTE_EXTEND_ON_MOVE_TO
     if (ctx->fflags & NOTE_EXTEND) {
         enqueue_event (ctx->iw, IN_MOVED_TO, di);
     } else
@@ -184,7 +184,7 @@ handle_removed (void *udata, dep_item *di)
     handle_context *ctx = (handle_context *) udata;
     assert (ctx->iw != NULL);
 
-#ifdef HAVE_NOTE_EXTEND_ON_SUBFILE_RENAME
+#ifdef HAVE_NOTE_EXTEND_ON_MOVE_FROM
     if (ctx->fflags & NOTE_EXTEND) {
         enqueue_event (ctx->iw, IN_MOVED_FROM, di);
     } else

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -265,7 +265,7 @@ produce_directory_diff (i_watch *iw, struct kevent *event)
     assert (event != NULL);
 
     DIR *dir;
-    dep_list *changes = NULL;
+    chg_list *changes = NULL;
 
 #if READDIR_DOES_OPENDIR > 0
     dir = fdreopendir (iw->fd);

--- a/worker-thread.c
+++ b/worker-thread.c
@@ -437,7 +437,7 @@ worker_thread (void *arg)
     worker* wrk = (worker *) arg;
     worker_cmd *cmd;
     size_t i, sbspace = 0;
-#define MAXEVENTS 32
+#define MAXEVENTS 1
     struct kevent received[MAXEVENTS];
 
     for (;;) {

--- a/worker-thread.h
+++ b/worker-thread.h
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/worker.c
+++ b/worker.c
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/worker.h
+++ b/worker.h
@@ -1,6 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+  Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
1. Directory diffing has been rewritten. No more memory hungry shallow lists allocations/deallocations
2. Fix compilation on platforms where kevent.data size is bigger than void * (issue #4)
3. Workaround sporadic crashes caused by reversing of kevent order (issue #5)