### PR TITLE
Respect --includedir in pkg-config

### DIFF
--- a/libinotify.pc.in
+++ b/libinotify.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
 
 Name: @PACKAGE_NAME@
 Description: Kqueue based inotify shim library


### PR DESCRIPTION
When libinotify is installed other software is eager to pick it up as if on Linux e.g., `AC_CHECK_HEADERS([sys/inotify.h])`. I'd like to use `--includedir` to move the header under subdirectory in order to limit consumers to those that don't have native kqueue support.