### PR TITLE
Direct mode feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,8 @@ AC_C_FLEXIBLE_ARRAY_MEMBER
 AC_HEADER_STDBOOL
 
 
-if [test "$ac_cv_prog_cc_c89" = "no"]; then
-    AC_MSG_ERROR(C89 compiler support required)
+if [test "$ac_cv_prog_cc_c99" = "no"]; then
+    AC_MSG_ERROR(C99 compiler support required)
 fi
 
 

--- a/event-queue.h
+++ b/event-queue.h
@@ -36,6 +36,7 @@ struct event_queue {
     int allocated;     /* number of iovs allocated */
     int max_events;    /* max_queued_events */
     struct inotify_event *last; /* Last event sent to socket */
+    uint user_ident;   /* ident for EVFILT_USER events when operating in direct mode */
 };
 
 void event_queue_init (struct event_queue *eq);
@@ -50,5 +51,7 @@ int  event_queue_enqueue       (struct event_queue *eq,
                                 const char         *name);
 ssize_t event_queue_flush      (struct event_queue *eq, size_t sbspace);
 void    event_queue_reset_last (struct event_queue *eq);
+
+struct iovec *event_queue_direct_drain (struct event_queue *eq);
 
 #endif /* __EVENT_QUEUE_H__ */

--- a/inotify-test.c
+++ b/inotify-test.c
@@ -135,7 +135,7 @@ static void dump_event (struct inotify_event *pevent, char* action)
         if (pevent->len) printf ("name=%s\n", pevent->name);
     */
 
-    printf ("%s [%s]\n", action, pevent->name);
+    printf ("%s [%s]\n", action, pevent->len ? pevent->name : "");
 }
 
 #define BUFF_SIZE (16*1024)

--- a/libinotify.3
+++ b/libinotify.3
@@ -1,5 +1,7 @@
 .\" Copyright (c) 2012 Vishesh Yadav
 .\" Copyright (c) 2017 Vladimr Kondratyev
+.\" Copyright (c) 2024 Serenity Cyber Security, LLC
+.\"                    Author: Gleb Popov
 .\" All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -25,7 +27,7 @@
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
 .\"
-.Dd April 13, 2017
+.Dd July 22, 2024
 .Dt LIBINOTIFY 3
 .Os
 .Sh NAME
@@ -36,6 +38,9 @@
 .Nm inotify_rm_watch ,
 .Nm libinotify_set_param ,
 .Nm inotify_event ,
+.Nm libinotify_direct_readv ,
+.Nm libinotify_free_iovec ,
+.Nm libinotify_direct_close ,
 .Nd monitor file system events
 .Sh SYNOPSIS
 .In sys/inotify.h
@@ -49,6 +54,12 @@
 .Fn inotify_rm_watch "int fd" "int wd"
 .Ft int
 .Fn libinotify_set_param "int fd" "int param" "intptr_t value"
+.Ft int
+.Fn libinotify_direct_readv "int fd" "struct iovec **events" "int size" "int no_block"
+.Ft void
+.Fn libinotify_free_iovec "struct iovec *events"
+.Ft int
+.Fn libinotify_direct_close "int fd"
 .Sh DESCRIPTION
 The
 .Fn inotify_init
@@ -66,6 +77,8 @@ Set I_NONBLOCK file status flag on the inotify file descriptor.
 .It IN_CLOSEXEC
 Set FD_CLOEXEC flag on the new file descriptor. See O_CLOEXEC flag in
 .Xr open(2)
+.It O_DIRECT
+libinotify-specific flag that enables direct mode (see below)
 .Pp
 .El
 The function returns the file descritor to the inotify handle if successful
@@ -102,7 +115,7 @@ A component of path that must exist does not exist.
 .It ENOMEM
 Insufficient kernel memory available.
 .It ENOSPC
-User limit on total number of inotify watches has crossed or kernel failed to 
+User limit on total number of inotify watches has crossed or kernel failed to
 allocate a needed resource.
 .El
 .Pp
@@ -143,7 +156,7 @@ linux`s /proc/sys/fs/inotify/max_user_instances counterpart.
 Default value 2147483646 (exported as IN_DEF_MAX_USER_INSTANCES)
 .El
 .Pp
-.Sh inotify_event structure 
+.Sh inotify_event structure
 .Bd -literal
 struct inotify_event {
     int         wd;       /* Watch descriptor */
@@ -153,7 +166,7 @@ struct inotify_event {
     char        name[];   /* Optional null-terminated name */
 };
 .Ed
-.Sh inotify events - 
+.Sh inotify events -
 Following are the masks supported by libinotify implementation.
 .Bd -literal -offset indent -compact
 IN_OPEN             File was opened.
@@ -205,6 +218,22 @@ Event queue has overflowed.
 .It IN_UNMOUNT
 File system containing watched file/directory was unmounted.
 .El
+.Sh DIRECT MODE
+In this mode the fd handed over to the user isn't a read()able one, but is actually a kqueue fd.
+This allows to reduce some copying overhead at the cost of being incompatible with how Linux inotify fd works.
+The mode is activated by passing O_DIRECT to inotify_init1().
+.Pp
+.Fn libinotify_direct_readv
+is a replacement for the read call in direct mode.
+Pass it an array of struct iovec* of desired size to fill it with lists of events.
+Each struct iovec* points to an array of structs terminated with a null iovec (iov_base = NULL).
+It is the caller responsibility to free these arrays.
+.Pp
+.Fn libinotify_free_iovec
+Frees a list of iovec structs returned by the previous call.
+.Pp
+.Fn libinotify_direct_close
+is a replacement for the close call in direct mode.
 .Sh SEE ALSO
 .Xr read 3
 .Sh HISTORY

--- a/libinotify.sym
+++ b/libinotify.sym
@@ -3,3 +3,6 @@ inotify_init1
 inotify_add_watch
 inotify_rm_watch
 libinotify_set_param
+libinotify_direct_readv
+libinotify_free_iovec
+libinotify_direct_close

--- a/tests/bugs_test.cc
+++ b/tests/bugs_test.cc
@@ -1,6 +1,8 @@
 /*******************************************************************************
   Copyright (c) 2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
   Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -40,9 +42,9 @@ void bugs_test::setup ()
 
 }
 
-void bugs_test::run ()
+void bugs_test::run (bool direct)
 {
-    consumer cons;
+    consumer cons(direct);
     events received;
     events::iterator iter;
     int wid = 0;

--- a/tests/bugs_test.hh
+++ b/tests/bugs_test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,7 +31,7 @@
 class bugs_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/tests/core/consumer.cc
+++ b/tests/core/consumer.cc
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -27,7 +29,8 @@
 #include "log.hh"
 #include "consumer.hh"
 
-consumer::consumer ()
+consumer::consumer (bool direct)
+: ino(direct)
 {
     pthread_create (&self, NULL, consumer::run_, this);
 }

--- a/tests/core/consumer.hh
+++ b/tests/core/consumer.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -43,7 +45,7 @@ public:
     request input;
     response output;
 
-    consumer ();
+    consumer (bool direct = false);
     ~consumer ();
     static void* run_ (void *ptr);
     void run ();

--- a/tests/core/inotify_client.hh
+++ b/tests/core/inotify_client.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,12 +31,15 @@
 
 class inotify_client {
     int fd;
+    bool direct;
 
 private:
     static time_t timems ();
+    static void read_events (int fd, events &evs);
+    static void read_events_direct (int fd, events &evs);
 
 public:
-    inotify_client ();
+    inotify_client (bool direct = false);
     ~inotify_client ();
     int watch (const std::string &filename, uint32_t flags);
     int cancel (int wid);

--- a/tests/core/inotify_client.hh
+++ b/tests/core/inotify_client.hh
@@ -1,6 +1,6 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
-  Copyright (c) 2024 Serenity Cybersecurity, LLC
+  Copyright (c) 2024 Serenity Cyber Security, LLC
                      Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 

--- a/tests/core/test.cc
+++ b/tests/core/test.cc
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -40,9 +42,11 @@ void* test::run_ (void *ptr)
 {
     assert (ptr != NULL);
     test *t = static_cast<test *>(ptr);
-    t->setup ();
-    t->run ();
-    t->cleanup ();
+    for (bool direct : {false, true}) {
+        t->setup ();
+        t->run (direct);
+        t->cleanup ();
+    }
     return NULL;
 }
 

--- a/tests/core/test.hh
+++ b/tests/core/test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -36,7 +38,7 @@ protected:
     static void* run_ (void *ptr);
 
     virtual void setup () = 0;
-    virtual void run () = 0;
+    virtual void run (bool direct) = 0;
     virtual void cleanup () = 0;
 
 public:

--- a/tests/event_queue_test.cc
+++ b/tests/event_queue_test.cc
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2016 Vladimir Kondratyev <vladimir@kondratyev.su>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -51,9 +53,9 @@ void event_queue_test::setup ()
     system ("touch eqt-working/1");
 }
 
-void event_queue_test::run ()
+void event_queue_test::run (bool direct)
 {
-    consumer cons;
+    consumer cons(direct);
     events received;
     int wid = 0;
 
@@ -75,9 +77,10 @@ void event_queue_test::run ()
     cons.input.receive ();
     cons.output.wait ();
     received = cons.output.registered ();
-    should ("receive single (coalesced) IN_ATTRIB on 2 consecutive "
-            "watched dir touches", received.size() == 1 &&
-             contains (received, event ("", wid, IN_ATTRIB)));
+    if (!direct)
+        should ("receive single (coalesced) IN_ATTRIB on 2 consecutive "
+                "watched dir touches", received.size() == 1 &&
+                contains (received, event ("", wid, IN_ATTRIB)));
 
 
     cons.output.reset ();
@@ -90,9 +93,10 @@ void event_queue_test::run ()
     cons.input.receive ();
     cons.output.wait ();
     received = cons.output.registered ();
-    should ("receive single (coalesced) IN_ATTRIB on 2 consecutive "
-            "subfile touches", received.size() == 1 &&
-            contains (received, event ("1", wid, IN_ATTRIB)));
+    if (!direct)
+        should ("receive single (coalesced) IN_ATTRIB on 2 consecutive "
+                "subfile touches", received.size() == 1 &&
+                contains (received, event ("1", wid, IN_ATTRIB)));
 
 
     /*
@@ -123,8 +127,9 @@ void event_queue_test::run ()
     cons.input.receive ();
     cons.output.wait ();
     received = cons.output.registered ();
-    should ("receive IN_Q_OVERFLOW on many consecutive touches",
-            contains (received, event ("", -1, IN_Q_OVERFLOW)));
+    if (!direct)
+        should ("receive IN_Q_OVERFLOW on many consecutive touches",
+                contains (received, event ("", -1, IN_Q_OVERFLOW)));
 
 
     cons.input.interrupt ();

--- a/tests/event_queue_test.hh
+++ b/tests/event_queue_test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2016 Vladimir Kondratyev <vladimir@kondratyev.su>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,7 +31,7 @@
 class event_queue_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/tests/fail_test.cc
+++ b/tests/fail_test.cc
@@ -1,6 +1,8 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
   Copyright (c) 2015 Vladimir Kondratyev <vladimir@kondratyev.su>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -49,9 +51,9 @@ void fail_test::setup ()
     system ("touch fail-working");
 }
 
-void fail_test::run ()
+void fail_test::run (bool direct)
 {
-    consumer cons;
+    consumer cons(direct);
     sig_t oldsegvhandler;
     int wid = 0;
     int error = 0;

--- a/tests/fail_test.hh
+++ b/tests/fail_test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,7 +31,7 @@
 class fail_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/tests/notifications_dir_test.cc
+++ b/tests/notifications_dir_test.cc
@@ -1,6 +1,8 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
   Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -53,9 +55,9 @@ void notifications_dir_test::setup ()
     system ("touch ntfsdt-bugs/2");
 }
 
-void notifications_dir_test::run ()
+void notifications_dir_test::run (bool direct)
 {
-    consumer cons;
+    consumer cons(direct);
     events received;
     events::iterator iter;
     int wid = 0;
@@ -70,7 +72,7 @@ void notifications_dir_test::run ()
 
     wid = cons.output.added_watch_id ();
     should ("watch is added successfully", wid != -1);
-    
+
 
     cons.output.reset ();
     cons.input.receive ();
@@ -137,7 +139,7 @@ void notifications_dir_test::run ()
     should ("receive IN_DELETE event on deleting a file from a directory",
             contains (received, event ("2", wid, IN_DELETE)));
 
-    
+
     cons.output.reset ();
     cons.input.receive ();
 
@@ -160,7 +162,7 @@ void notifications_dir_test::run ()
                 iter_from->cookie == iter_to->cookie);
     }
 
-    
+
     cons.output.reset ();
     cons.input.receive ();
 
@@ -275,7 +277,7 @@ void notifications_dir_test::run ()
                          event_matcher (event ("dir", wid, IN_CREATE)));
     should ("receive IN_CREATE with IN_ISDIR when creating a directory in directory",
             iter != received.end() && iter->flags & IN_ISDIR);
-    
+
 
     cons.output.reset ();
     cons.input.receive ();
@@ -291,7 +293,7 @@ void notifications_dir_test::run ()
     should ("receive IN_ATTRIB with IN_ISDIR when touching a directory in directory",
             iter != received.end() && iter->flags & IN_ISDIR);
 
-    
+
     cons.output.reset ();
     cons.input.receive ();
 
@@ -350,8 +352,8 @@ void notifications_dir_test::run ()
 
     should ("receive IN_DELETE with IN_ISDIR when removing directory in directory",
             iter != received.end () &&  (iter->flags & IN_ISDIR));
-    
-    
+
+
     cons.output.reset ();
     cons.input.receive ();
 
@@ -390,6 +392,7 @@ void notifications_dir_test::run ()
 
     cons.output.wait ();
     received = cons.output.registered ();
+
     should ("receive IN_DELETE for a file \'one\' in a directory on removing a directory",
             contains (received, event ("one", wid, IN_DELETE)));
     should ("receive IN_DELETE for a file \'foo\' in a directory on removing a directory",

--- a/tests/notifications_dir_test.hh
+++ b/tests/notifications_dir_test.hh
@@ -29,7 +29,7 @@
 class notifications_dir_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/tests/notifications_test.cc
+++ b/tests/notifications_test.cc
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -37,9 +39,9 @@ void notifications_test::setup ()
     system ("touch ntfst-working");
 }
 
-void notifications_test::run ()
+void notifications_test::run (bool direct)
 {
-    consumer cons;
+    consumer cons(direct);
     events received;
     int wid = 0;
     int error = 0;
@@ -81,7 +83,7 @@ void notifications_test::run ()
     received = cons.output.registered ();
     should ("receive IN_MOVE_SELF on move", contains (received, event ("", wid, IN_MOVE_SELF)));
 
-    
+
     cons.output.reset ();
     cons.input.receive ();
 

--- a/tests/notifications_test.hh
+++ b/tests/notifications_test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,7 +31,7 @@
 class notifications_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/tests/open_close_test.cc
+++ b/tests/open_close_test.cc
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -46,9 +48,9 @@ void open_close_test::setup ()
     system ("mkdir oct-dir-working");
 }
 
-void open_close_test::run ()
+void open_close_test::run (bool direct)
 {
-    consumer cons;
+    consumer cons(direct);
     int file_wid = 0;
     int dir_wid = 0;
     events received;

--- a/tests/open_close_test.hh
+++ b/tests/open_close_test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,7 +31,7 @@
 class open_close_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/tests/start_stop_dir_test.cc
+++ b/tests/start_stop_dir_test.cc
@@ -1,6 +1,8 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
   Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -40,16 +42,16 @@ start_stop_dir_test::start_stop_dir_test (journal &j)
 void start_stop_dir_test::setup ()
 {
     cleanup ();
-    
+
     system ("mkdir ssdt-working");
     system ("touch ssdt-working/1");
     system ("touch ssdt-working/2");
     system ("touch ssdt-working/3");
 }
 
-void start_stop_dir_test::run ()
+void start_stop_dir_test::run (bool direct)
 {
-    consumer cons;
+    consumer cons(direct);
     events received;
     int wid = 0;
     int error = 0;
@@ -81,7 +83,7 @@ void start_stop_dir_test::run ()
     system ("touch ssdt-working/1");
     system ("touch ssdt-working/2");
     system ("touch ssdt-working/3");
-    
+
     cons.output.wait ();
     received = cons.output.registered ();
     should ("events are registered on the directory contents",
@@ -97,7 +99,7 @@ void start_stop_dir_test::run ()
     /* Linux inotify sends IN_IGNORED on stop */
     cons.output.reset ();
     cons.input.receive ();
-    
+
     cons.output.wait ();
     received = cons.output.registered ();
     should ("got IN_IGNORED on watch stop",

--- a/tests/start_stop_dir_test.hh
+++ b/tests/start_stop_dir_test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,7 +31,7 @@
 class start_stop_dir_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/tests/start_stop_test.cc
+++ b/tests/start_stop_test.cc
@@ -1,6 +1,8 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
   Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -45,9 +47,9 @@ void start_stop_test::setup ()
     system ("ln -s sst-working sst-working3");
 }
 
-void start_stop_test::run ()
+void start_stop_test::run (bool direct)
 {
-    consumer cons;
+    consumer cons(direct);
     int wid = 0;
     int wid2 = 0;
     int error = 0;
@@ -88,11 +90,11 @@ void start_stop_test::run ()
     received = cons.output.registered ();
     should ("got IN_IGNORED on watch stop",
             contains (received, event ("", wid, IN_IGNORED)));
-    
+
     /* Tell again to consumer to watch for an IN_ATTRIB event  */
     cons.output.reset ();
     cons.input.receive ();
-    
+
     system ("touch sst-working");
 
     cons.output.wait ();

--- a/tests/start_stop_test.hh
+++ b/tests/start_stop_test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,7 +31,7 @@
 class start_stop_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/tests/symlink_test.cc
+++ b/tests/symlink_test.cc
@@ -1,6 +1,8 @@
 /*******************************************************************************
   Copyright (c) 2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
   Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -48,10 +50,10 @@ void symlink_test::setup ()
     system ("ln -s ../slt-wd1/foo slt-wd3/baz");
 }
 
-void symlink_test::run ()
+void symlink_test::run (bool direct)
 {
     /* Issue #10 - do not reflect changes in files under watched symlinks */
-    {   consumer cons;
+    {   consumer cons(direct);
         events received;
         events::iterator iter;
         int wid = 0;

--- a/tests/symlink_test.hh
+++ b/tests/symlink_test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,7 +31,7 @@
 class symlink_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/tests/update_flags_dir_test.cc
+++ b/tests/update_flags_dir_test.cc
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -37,9 +39,9 @@ void update_flags_dir_test::setup ()
     system ("touch ufdt-working/1");
 }
 
-void update_flags_dir_test::run ()
+void update_flags_dir_test::run (bool direct)
 {
-    consumer cons;
+    consumer cons(direct);
     int wid = 0;
     int new_wid = 0;
     events received;

--- a/tests/update_flags_dir_test.hh
+++ b/tests/update_flags_dir_test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,7 +31,7 @@
 class update_flags_dir_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/tests/update_flags_test.cc
+++ b/tests/update_flags_test.cc
@@ -1,6 +1,8 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
   Copyright (c) 2014 Vladimir Kondratyev <vladimir@kondratyev.su>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -37,9 +39,9 @@ void update_flags_test::setup ()
     system ("touch uft-working");
 }
 
-void update_flags_test::run ()
+void update_flags_test::run (bool direct)
 {
-    consumer cons;
+    consumer cons(direct);
     int wid = 0;
     int updated_wid = 0;
     events received;
@@ -47,10 +49,10 @@ void update_flags_test::run ()
     /* Add a watch */
     cons.input.setup ("uft-working", IN_ATTRIB);
     cons.output.wait ();
-    
+
     wid = cons.output.added_watch_id ();
     should ("start watching successfully", wid != -1);
-    
+
 
     cons.output.reset ();
     cons.input.receive ();

--- a/tests/update_flags_test.hh
+++ b/tests/update_flags_test.hh
@@ -1,5 +1,7 @@
 /*******************************************************************************
   Copyright (c) 2011 Dmitry Matveev <me@dmitrymatveev.co.uk>
+  Copyright (c) 2024 Serenity Cybersecurity, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,7 +31,7 @@
 class update_flags_test: public test {
 protected:
     virtual void setup ();
-    virtual void run ();
+    virtual void run (bool direct);
     virtual void cleanup ();
 
 public:

--- a/utils.c
+++ b/utils.c
@@ -23,6 +23,7 @@
 *******************************************************************************/
 
 #include <sys/types.h>
+#include <sys/event.h> /* kqueue[1] */
 #include <sys/socket.h>/* send, sendmsg */
 #include <sys/stat.h>  /* fstat */
 #include <sys/uio.h>   /* writev */
@@ -61,6 +62,24 @@ perror_msg_printf (const char *fmt, ...)
     return buf;
 }
 #endif
+
+int
+kqueue_init (void)
+{
+    int kq;
+#ifdef HAVE_KQUEUE1
+    kq = kqueue1 (O_CLOEXEC);
+#else
+    kq = kqueue ();
+    if (kq != -1) {
+        (void)set_cloexec_flag (kq, 1);
+    }
+#endif
+    if (kq == -1) {
+        perror_msg (("Failed to create a new kqueue"));
+    }
+    return kq;
+}
 
 /**
  * Create a new inotify event.

--- a/utils.h
+++ b/utils.h
@@ -65,6 +65,8 @@ do {                                                                    \
 #define perror_msg(msg)
 #endif
 
+int kqueue_init (void);
+
 struct inotify_event* create_inotify_event (int         wd,
                                             uint32_t    mask,
                                             uint32_t    cookie,

--- a/worker.h
+++ b/worker.h
@@ -1,6 +1,8 @@
 /*******************************************************************************
   Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
   Copyright (c) 2014-2018 Vladimir Kondratyev <vladimir@kondratyev.su>
+  Copyright (c) 2024 Serenity Cyber Security, LLC
+                     Author: Gleb Popov <arrowd@FreeBSD.org>
   SPDX-License-Identifier: MIT
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -45,7 +47,8 @@ typedef enum {
     WCMD_NONE = 0,   /* uninitialized state */
     WCMD_ADD,        /* add or modify a watch */
     WCMD_REMOVE,     /* remove a watch */
-    WCMD_PARAM       /* set worker thread parameter */
+    WCMD_PARAM,      /* set worker thread parameter */
+    WCMD_CLOSE       /* signal worker thread to shutdown itself */
 } worker_cmd_type_t;
 
 /**
@@ -78,6 +81,7 @@ void worker_cmd_add    (struct worker_cmd *cmd,
                         uint32_t mask);
 void worker_cmd_remove (struct worker_cmd *cmd, int watch_id);
 void worker_cmd_param  (struct worker_cmd *cmd, int param, intptr_t value);
+void worker_cmd_close  (struct worker_cmd *cmd);
 
 SLIST_HEAD(workers_list, worker);
 


### PR DESCRIPTION
libinotify-kqueue is a gem of software that does two things:
* It implements a sophisticated filesystem changes detection algorithm via
  kqueue/kevent API (for instance, tracking renames or diff'ing directory contents)
* It exposes this functionality via Linux inotify interface, which allows the
  library to be used as a drop-in compatibility shim

The compatibility, however, comes at cost, since the library has to emulate
the inotify descriptor via an unix domain socket. This means that delivering an
event involves copying the data into the kernel and then pulling it back.

This change adds a special operating mode for libinotify-kqueue dubbed "direct".
In this mode the socket pipe is replaced with another kqueue that is used to
deliver events via a kevent(EVFILT_USER) call.
Using this mode requires minor changes to the client code compared to using
plain inotify API, but in return it allows for reusing libinotify's algorithms
without a performance penalty.